### PR TITLE
Changed the word 'Tutors' to 'TAs'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # Introduction of Robust Protocol Open Challenge
 
 ## GCC 2021 Online  
+
 ### Speaker
+
 Michihiro Imaoka (Hiro) JP  
 @imaoca  
 imaoca@gmail.com  
 https://www.facebook.com/imaoka.micihihiro/
 
-### Tutors
-Yuya Tsuru<br>
+### TAs
+
+Yuya Tsuru  
 Naoki Takayama
 
 # Background


### PR DESCRIPTION
In GCC, we are not using word "Tutors", because its not much used in general.
For an alternative, we are using word "TAs (Teaching Assistants)" to indicate this group of peoples.